### PR TITLE
Add search and pagination [DO NOT MERGE needs build fixing]

### DIFF
--- a/lib/paginated.rb
+++ b/lib/paginated.rb
@@ -1,0 +1,44 @@
+module Paginated
+  def filter_and_paginate(sym)
+    original_method = :"#{sym}_no_pagination"
+    alias_method original_method, sym
+    define_method sym do |page, text, *args|
+      results = send(original_method, *args)
+      filtered = self.class.filter(results, text)
+      self.class.paginate(filtered, page, @config_options)
+    end
+  end
+
+  def filter(results, text)
+    if text.empty?
+      results
+    elsif
+      text = text.downcase
+      results.select { |record| record[:item].values.to_s.downcase.include?(text) }
+    end
+  end
+
+  def paginate(results, page, config_options)
+    if results.length <= config_options[:page_size]
+      {
+        data: results,
+        page: 1,
+        total_results: results.length,
+        total_pages: 1,
+        more_results: false
+      }
+    elsif
+      start_index = (page - 1) * config_options[:page_size]
+      total_results = results.length
+      total_pages = (results.length / config_options[:page_size].to_f).ceil
+
+      {
+        data: results.slice(start_index, config_options[:page_size]),
+        page: page,
+        total_results: total_results,
+        total_pages: total_pages,
+        more_results: page < total_pages
+      }
+    end
+  end
+end

--- a/lib/paginated.rb
+++ b/lib/paginated.rb
@@ -2,24 +2,24 @@ module Paginated
   def filter_and_paginate(sym)
     original_method = :"#{sym}_no_pagination"
     alias_method original_method, sym
-    define_method sym do |page, text, *args|
+    define_method sym do |page = 1, text = '', *args|
       results = send(original_method, *args)
       filtered = self.class.filter(results, text)
-      self.class.paginate(filtered, page, @config_options)
+      self.class.paginate(filtered, page, @config_options[:page_size])
     end
   end
 
   def filter(results, text)
     if text.empty?
       results
-    elsif
+    else
       text = text.downcase
       results.select { |record| record[:item].values.to_s.downcase.include?(text) }
     end
   end
 
-  def paginate(results, page, config_options)
-    if results.length <= config_options[:page_size]
+  def paginate(results, page = 1, page_size = 100)
+    if page.nil? || results.length <= page_size
       {
         data: results,
         page: 1,
@@ -28,12 +28,12 @@ module Paginated
         more_results: false
       }
     elsif
-      start_index = (page - 1) * config_options[:page_size]
+      start_index = (page - 1) * page_size
       total_results = results.length
-      total_pages = (results.length / config_options[:page_size].to_f).ceil
+      total_pages = (results.length / page_size.to_f).ceil
 
       {
-        data: results.slice(start_index, config_options[:page_size]),
+        data: results.slice(start_index, page_size),
         page: page,
         total_results: total_results,
         total_pages: total_pages,

--- a/lib/registers_client.rb
+++ b/lib/registers_client.rb
@@ -1,29 +1,31 @@
 require 'register_client'
+require 'Paginated'
 
 module RegistersClient
-    VERSION = '0.1.0' unless defined? OpenRegister::VERSION
-    class RegistersClientManager
-      def initialize(config_options = {})
-        @config_options = defaults.merge(config_options)
-        @register_clients = {}
+  VERSION = '0.2.0' unless defined? OpenRegister::VERSION
+  class RegistersClientManager
+    def initialize(config_options = {})
+      @config_options = defaults.merge(config_options)
+      @register_clients = {}
+    end
+
+    def get_register(register, phase)
+      key = register + ':' + phase
+
+      if !@register_clients.key?(key)
+        @register_clients[key] = RegistersClient::RegisterClient.new register, phase, @config_options
       end
-  
-      def get_register(register, phase)
-        key = register + ':' + phase
-  
-        if !@register_clients.key?(key)
-          @register_clients[key] = RegistersClient::RegisterClient.new register, phase, @config_options
-        end
-  
-        @register_clients[key]
-      end
-  
-      private
-  
-      def defaults
-        {
-            cache_duration: 30
-        }
-      end
+
+      @register_clients[key]
+    end
+
+    private
+
+    def defaults
+      {
+        cache_duration: 30,
+        page_size: 100
+      }
     end
   end
+end

--- a/registers-ruby-client.gemspec
+++ b/registers-ruby-client.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: registers-ruby-client 0.1.0 ruby lib
+# stub: registers-ruby-client 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "registers-ruby-client".freeze
-  s.version = "0.1.0"
+  s.version = "0.2.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]


### PR DESCRIPTION
This PR adds filtering and pagination to the client library. All methods (except `get_register_definition` and `get_custodian`) now return a JSON response containing the particular results of the method that was called, in addition to the current page, number of total pages, number of results and a flag `more_results` to indicate if there are any more results to retrieve. 

A new `page_size` option is added to the `config_options` object and defaults to `100` records.

Finally, the version is updated to 0.2.0.