### PR TITLE
Increase performance of parsing RSF

### DIFF
--- a/lib/register_client.rb
+++ b/lib/register_client.rb
@@ -73,9 +73,10 @@ module RegistersClient
     end
 
     def parse_rsf(rsf)
-      items = []
+      items = {}
       entries = { user: [], system: [] }
       records = { user: {}, system: {} }
+      entry_number = 1
 
       rsf.each_line do |line|
         line.slice!("\n")
@@ -84,13 +85,13 @@ module RegistersClient
         command = params[0]
 
         if command == 'add-item'
-          items << parse_item(params[1])
+          item = parse_item(params[1])
+          items[item[:hash].to_s] = item
         elsif command == 'append-entry'
           key = params[2]
-          entry_number = entries[:user].count + 1
           entry_timestamp = params[3]
           current_item_hash = params[4]
-          record = parse_entry(key, entry_number, entry_timestamp, current_item_hash, JSON.parse(items.find { |item| item[:hash] == current_item_hash }[:item]))
+          record = parse_entry(key, entry_number, entry_timestamp, current_item_hash, JSON.parse(items[current_item_hash][:item]))
 
           if params[1] == 'user'
             if !records[:user].key?(key)
@@ -108,6 +109,8 @@ module RegistersClient
             entries[:system] << record
           end
         end
+
+        entry_number += 1
       end
 
       { records: records, entries: entries, items: items }

--- a/lib/registers_client.rb
+++ b/lib/registers_client.rb
@@ -1,7 +1,7 @@
 require 'register_client'
 
 module RegistersClient
-    VERSION = '0.1.0' unless defined? OpenRegister::VERSION
+    VERSION = '0.1.1' unless defined? OpenRegister::VERSION
     class RegistersClientManager
       def initialize(config_options = {})
         @config_options = defaults.merge(config_options)

--- a/registers-ruby-client.gemspec
+++ b/registers-ruby-client.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: registers-ruby-client 0.1.0 ruby lib
+# stub: registers-ruby-client 0.1.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "registers-ruby-client".freeze
-  s.version = "0.1.0"
+  s.version = "0.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]


### PR DESCRIPTION
This commit changes the register client to use a map instead of array for storing items. This is necessary as the number of entries increases to ensure constant-time lookup of an item when parsing entries.