### PR TITLE
Adds context to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 You can use this Ruby client to integrate your service with [GOV.UK Registers](https://registers.cloudapps.digital/).
 
-Registers are lists of information. Each register is the most reliable list of its kind. For example, the Foreign and Commonwealth Office’s (FCO’s) [country register](https://country.register.gov.uk/) is the most accurate and up-to-date list of countries available.
+Registers are authoritative lists of information, and the data is owned by 'custodians' inside departments and services. For example, the [country register](https://country.register.gov.uk/) is maintained by a custodian in the Foreign and Commonwealth Office’s (FCO). 
 
 ## Installation
 In your Gemfile add:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # GOV.UK Registers Ruby Client
 
-You can use this Ruby client to integrate your service with GOV.UK Registers. 
+You can use this Ruby client to integrate your service with [GOV.UK Registers](https://registers.cloudapps.digital/).
+
+Registers are lists of information. Each register is the most reliable list of its kind. For example, the Foreign and Commonwealth Office’s (FCO’s) [country register](https://country.register.gov.uk/) is the most accurate and up-to-date list of countries available.
 
 ## Installation
 In your Gemfile add:


### PR DESCRIPTION

### Context
There is no explanation of what the GOV.UK Registers team work on or what registers are (or links to that information) in the current version of the client library README. @arnau pointed out this could be problematic in case someone visited from outside GOV.UK 

### Changes proposed in this pull request
Adds some background of what registers are and relevant links 

### Guidance to review
N/A