### PR TITLE
Change entry point focus: `RegisterClientManager`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ registers_client = RegistersClient::RegisterClientManager.new({
 })
 ```
 
-The `RegisterClientManager` will maintain an invidual instance of `RegisterClient` each time you access a register by calling [`get_register`](#getregister).
+The `RegisterClientManager` maintains an invidual instance of [`RegisterClient`](#registerclient) for each time you access a register by calling [`get_register`](#getregister).
 
 `get_register` is the only public method available on `RegisterClientManager`.
 
@@ -490,7 +490,7 @@ ull}}]],
 ```
 </details>
 
-## `RegisterClient`
+## <a name="registerclient"></a>`RegisterClient`
 
 _Note: All examples use the `country` register._
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,13 @@ registers_client = RegistersClient::RegisterClientManager.new({
 })
 ```
 
-The `RegisterClientManager` maintains an invidual instance of [`RegisterClient`](#registerclient) for each time you access a register by calling [`get_register`](#getregister).
-
-`get_register` is the only public method available on `RegisterClientManager`.
+_The `RegisterClientManager` maintains individual instances of [`RegisterClient`](#registerclient) for each register you access via the [`get_register`](#getregister) method_
 
 When creating a new `RegisterClientManager`, you can pass a configuration object to specify the following:
 - `cache_duration`: time, in seconds, register data is cached in-memory before any updates are retrieved - default is `3600`
 - `page_size`: number of results returned per page when using the `page` method of any of the collection classes (see below for more information) - default is `100`
 
-### <a name="getregister"></a>`get_register(register, phase, data_store = nil)`
+### <a id="getregister"></a>`get_register(register, phase, data_store = nil)`
 
 Gets the `RegisterClient` instance for the given `register` name and `phase`.
 
@@ -490,7 +488,7 @@ ull}}]],
 ```
 </details>
 
-## <a name="registerclient"></a>`RegisterClient`
+## <a id="registerclient"></a>`RegisterClient`
 
 _Note: All examples use the `country` register._
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-rub
 ```
 ## Getting started 
 
+The `RegisterClientManager` is the entry point of Registers Ruby client. 
+
 ```
 require 'register_client_manager'
 
@@ -28,15 +30,15 @@ registers_client = RegistersClient::RegisterClientManager.new({
 })
 ```
 
-The `RegisterClientManager` maintains individual instances of `RegisterClient` for each register you access. 
+The `RegisterClientManager` will maintain an invidual instance of `RegisterClient` each time you access a register by calling [`get_register`](#getregister).
+
+`get_register` is the only public method available on `RegisterClientManager`.
 
 When creating a new `RegisterClientManager`, you can pass a configuration object to specify the following:
 - `cache_duration`: time, in seconds, register data is cached in-memory before any updates are retrieved - default is `3600`
 - `page_size`: number of results returned per page when using the `page` method of any of the collection classes (see below for more information) - default is `100`
 
-There is one public method available on `RegisterClientManager`:
-
-### `get_register(register, phase, data_store = nil)`
+### <a name="getregister"></a>`get_register(register, phase, data_store = nil)`
 
 Gets the `RegisterClient` instance for the given `register` name and `phase`.
 


### PR DESCRIPTION
### Context
Currently the documentation is written such that it implies `RegisterClient`, rather than `RegisterClientManager` is the main entry point for the client library.

### Changes proposed in this pull request
I've made some suggestions to try to change the focus (of the entry point) to `RegisterClientManager` rather than `RegisterClient`.

These are only suggestions and I've only made them to try to steer the PR in the right direction.

### Guidance to review
