### PR TITLE
Language surrounding `data_store`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When creating a new `RegisterClientManager`, you can pass a configuration object
 
 Gets the `RegisterClient` instance for the given `register` name and `phase`.
 
-The `data_store` parameter specifies the data store to use accessing a particular register. By default this parameter can be omitted to use the `InMemoryDataStore`; however, a custom data store can be created (for example, to insert register data directly into your Postgres database) which `includes DataStore` module and implements the methods it defines.
+The `data_store` parameter specifies the data store to use accessing a particular register. You can omit this parameter, which will make it default to the `InMemoryDataStore` value. You can create a custom data store to include the `DataStore` module and to implement the methods it defines. For example, to insert register data directly into your Postgres database. 
 
 <details>
 <summary>
@@ -490,7 +490,7 @@ ull}}]],
 ```
 </details>
 
-## <a id="registerclient"></a>`The RegisterClient class`
+## <a id="registerclient"></a>The `RegisterClient` class
 
 _Note: All examples use the [Country register](https://country.register.gov.uk/)._
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When creating a new `RegisterClientManager`, you can pass a configuration object
 
 Gets the `RegisterClient` instance for the given `register` name and `phase`.
 
-The `data_store` parameter specifies the data store to use accessing a particular register. You can omit this parameter, which will make it default to the `InMemoryDataStore` value. You can create a custom data store to include the `DataStore` module and to implement the methods it defines. For example, to insert register data directly into your Postgres database. 
+The `data_store` parameter specifies the data store to use accessing a particular register. You can omit this parameter, which will make it default to the `InMemoryDataStore` value. You can also create a custom data store to include the `DataStore` module and to implement the methods it defines. For example, to insert register data directly into your Postgres database. 
 
 <details>
 <summary>


### PR DESCRIPTION
### Context
I've made some suggested changes to the language surrounding `data_store`. Firstly I've just made the sentence a bit more accessible by breaking it up per GDS style, but in the process I've also made some changes to the actual language, which includes technical aspects of it. For example, I've removed the backticks around the statement "include" since I think that should be intuitive enough without them and seems to be the norm in Ruby documentation (when in "natural language" rather than "code snippet" form). Please correct me if I'm wrong :)

### Changes proposed in this pull request


### Guidance to review
