### PR TITLE
Split: 'Installation/Get started' and 'Reference'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Registers are authoritative lists of information. The data is owned by [custodia
 - [Reference](#reference)
   * [`RegisterClientManager`](#registerclientmanager)
   * [`RegisterClient`](#registerclient) 
-  * [Collections](#collections)
-    + [Items, entries and records](#items-entries-and-records)
-  
+  * [Collections](#collections)  
 
 ## Installation
 
@@ -368,6 +366,8 @@ Downloads register data. Call this method when you want to refresh data immediat
 
 The majority of the methods available in the `RegisterClient` return one of three types of collection object. These collections all include `Enumerable` and implement the `each` method.
 
+[`ItemCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/item_collection.rb), [`EntryCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/entry_collection.rb) and [`RecordCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/record_collection.rb) are all `Enumerable` and implement the same [Collections](#collections) interface.
+
 ### EntryCollection
 
 A collection of `Entry` objects.
@@ -495,11 +495,7 @@ ull}}]],
 ```
 </details>
 
-## Items, entries and records
-
-[`ItemCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/item_collection.rb), [`EntryCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/entry_collection.rb) and [`RecordCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/record_collection.rb) are all `Enumerable` and implement the same [Collections](#collections) interface.
-
-### Item
+### `Item`
 
 #### `hash`
 
@@ -588,7 +584,7 @@ true
 ```
 </details>
 
-### Entry
+### `Entry`
 
 #### `entry_number`
 
@@ -729,7 +725,7 @@ Expected output (click here to expand):
 ```
 </details>
 
-### Record
+### `Record`
 
 #### `entry`
 

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ The majority of the methods available in the `RegisterClient` return one of thre
 
 [`ItemCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/item_collection.rb), [`EntryCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/entry_collection.rb) and [`RecordCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/record_collection.rb) are all `Enumerable` and implement the same [Collections](#collections) interface.
 
-### EntryCollection
+### `EntryCollection`
 
 A collection of `Entry` objects.
 
@@ -382,7 +382,7 @@ Returns all `Entry` objects in the collection, according to the specified `page`
 
 If there are fewer results than the current `page_size`, all results are returned.
 
-### RecordCollection
+### `RecordCollection`
 
 A collection of `Record` objects.
 
@@ -396,7 +396,7 @@ Returns `Record` objects in the collection, according to the specified `page` nu
 
 If there are fewer results than the current `page_size`, all results are returned.
 
-### RecordMapCollection
+### `RecordMapCollection`
 
 A map of record key to list of both the current and historical `Record` objects for each key.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ Registers are authoritative lists of information. The data is owned by [custodia
 
 ## Table of Contents
 
-* [Installation](#installation)
-* [Get started](#get-started)
-* [Items, entries and records](#items-entries-and-records)
-* [Collections](#collections)
-* [The `RegisterClient` class](#registerclient) 
+- [Installation](#installation)
+- [Get started](#get-started)
+- [Reference](#reference)
+  * [`RegisterClientManager`](#registerclientmanager)
+  * [`RegisterClient`](#registerclient) 
+  * [Collections](#collections)
+    + [Items, entries and records](#items-entries-and-records)
+  
 
 ## Installation
 
@@ -38,7 +41,11 @@ When creating a new `RegisterClientManager`, you can pass a configuration object
 - `cache_duration`: time, in seconds, register data is cached in-memory before any updates are retrieved - default is `3600`
 - `page_size`: number of results returned per page when using the `page` method of any of the collection classes (see below for more information) - default is `100`
 
-### <a id="getregister"></a>`get_register(register, phase, data_store = nil)`
+## Reference
+
+### <a id="registerclientmanager"></a>`RegisterClientManager`
+
+##### <a id="getregister"></a>`get_register(register, phase, data_store = nil)`
 
 Gets the `RegisterClient` instance for the given `register` name and `phase`.
 
@@ -67,9 +74,430 @@ A RegisterClient instance e.g. #<RegistersClient::RegisterClient:0x00007f893c55f
 ```
 </details>
 
+### <a id="registerclient"></a>`RegisterClient` 
+
+_Note: All examples use the [Country register](https://country.register.gov.uk/)._
+
+#### `get_entries`
+
+Get all entries from the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_entries.first.item_hash
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+
+sha-256:a074752a77011b18447401652029a9129c53b4ee35e1d99e6dec8b42ff4a0103
+
+```
+</details>
+
+#### `get_records`
+
+Get all records from the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_records.first.item.value
+
+```
+</details>
+<details>
+
+<summary>
+Expected output (click here to expand):
+</summary>
+
+```
+
+{"citizen-names"=>"Soviet citizen", "country"=>"SU", "end-date"=>"1991-12-25", "name"=>"USSR", "official-name"=>"Union of Soviet Socialist Republics"}
+
+```
+
+</details>
+
+#### `get_metadata_records`
+
+Get all metadata records of the register. This includes the register definition, field definitions and custodian.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_metadata_records.first.item.value
+
+```
+</details>
+<details>
+
+<summary>
+Expected output (click here to expand):
+</summary>
+
+```
+
+{"name"=>"country"}
+
+```
+</details>
+
+#### `get_field_definitions`
+
+Get definitions for the fields used in the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_field_definitions.first.item.value
+
+```
+
+</details>
+<details>
+
+<summary>
+Expected output (click here to expand):
+</summary>
+
+```
+
+{"cardinality"=>"1", "datatype"=>"string", "field"=>"country", "phase"=>"beta", "register"=>"country", "text"=>"The country's 2-letter ISO 3166-2 alpha2 code."}
+
+```
+
+</details>
+
+#### `get_register_definition`
+
+Get the definition of the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+ </summary>
+
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_register_definition.item.value
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+</summary>
+
+```
+
+{"fields":["country","name","official-name","citizen-names","start-date","end-date"],"phase":"beta","register":"country","registry":"foreign-commonwealth-office","text":"British English-language names and descriptive terms for countries"}
+
+```
+
+</details>
+
+#### `get_custodian`
+
+Get the name of the current custodian for the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_custodian.item.value['custodian']
+
+```
+
+</details>
+<details>
+
+<summary>
+Expected output (click here to expand):
+</summary>
+
+```
+
+David de Silva
+
+```
+
+</details>
+
+#### `get_records_with_history`
+
+Get current and previous versions of records in the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+germany = register_data.get_records_with_history.get_records_for_key('DE').first
+puts germany.to_json
+
+```
+
+</details>
+
+<details>
+<summary>
+Expected output (click here to expand):
+</summary>
+
+```
+
+{"key":"DE","records":[{"key":"DE","entry_number":234,"timestamp":"2016-04-05T13:23:05Z","hash":"sha-256:e03f97c2806206cdc2cc0f393d09b18a28c6f3e6218fc8c6f3aa2fdd7ef9d625","item":{"citizen-names":"West German","country":"DE","end-date":"1990-10-02","name":"West Germany","official-name":"Federal Republic of Germany"}}
+
+```
+
+</details>
+
+#### `get_current_records`
+
+Get all current records from the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_current_records.first.item
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+</summary>
+
+```
+
+{"citizen-names"=>"German", "country"=>"DE", "name"=>"Germany", "official-name"=>"The Federal Republic of Germany", "start-date"=>"1990-10-03"}
+
+```
+
+</details>
+
+#### `get_expired_records`
+
+Get all expired records from the register.
+
+<details>
+<summary>
+Example use (click here to expand)
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_expired_records.first.item
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand)
+</summary>
+
+```
+
+{"citizen-names"=>"Soviet citizen", "country"=>"SU", "end-date"=>"1991-12-25", "name"=>"USSR", "official-name"=>"Union of Soviet Socialist Republics"}
+
+```
+
+</details>
+
+#### `refresh_data`
+
+Downloads register data. Call this method when you want to refresh data immediately rather than waiting for the `cache_duration` to expire.
+
+## Collections
+
+The majority of the methods available in the `RegisterClient` return one of three types of collection object. These collections all include `Enumerable` and implement the `each` method.
+
+### EntryCollection
+
+A collection of `Entry` objects.
+
+#### `each`
+
+Yields each `Entry` object in the collection.
+
+#### `page(int page=1)`
+
+Returns all `Entry` objects in the collection, according to the specified `page` number (defaults to `1`).
+
+If there are fewer results than the current `page_size`, all results are returned.
+
+### RecordCollection
+
+A collection of `Record` objects.
+
+#### `each`
+
+Yields each `Record` object in the collection.
+
+#### `page(int page=1)`
+
+Returns `Record` objects in the collection, according to the specified `page` number (defaults to `1`).
+
+If there are fewer results than the current `page_size`, all results are returned.
+
+### RecordMapCollection
+
+A map of record key to list of both the current and historical `Record` objects for each key.
+
+#### `each`
+
+Yields each record key to list of current and historical `Record` objects in the collection, in the following format:
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_records_with_history.each do |result|
+  puts result.to_json
+end
+
+```
+</details>
+<details>
+<summary>
+Expected output for the first `result` (click here to expand):
+ </summary>
+
+```
+
+"{"key":"SU","records":[{"entry":{"rsf_line":null,"entry_number":1,"parsed_entry":{"key":"SU","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"}},"item":{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}}]}"
+
+```
+</details>
+
+#### `get_records_for_key(string key)`
+
+Returns both the current and historical `Record` objects for a given key, or raises a `KeyError` if no records exist for the given key.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+register_data.get_records_with_history.get_records_for_key('SU')
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+
+"{[{"entry":{"rsf_line":null,"entry_number":1,"parsed_entry":{"key":"SU","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"}},"item":{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}}]}"
+
+```
+</details>
+
+#### `paginator`
+
+Returns an enumerator of a map of record key to list of current and historical `Record` objects in the collection, in slices specified by `page_size` (defined when creating the `RegisterClientManager`).
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+enumerator = register_data.get_records_with_history.paginator
+enumerator.next.to_json
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+
+[["SU",[{"entry":{"rsf_line":null,"entry_number":1,"parsed_entry":{"key":"SU","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"}},"item":{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}}]],["DE",[{"entry":{"rsf_line":null,"entry_number":2,"parsed_entry":{"key":"DE","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e03f97c2806206cdc2cc0f393d09b18a28c6f3e6218fc8c6f3aa2fdd7ef9d625"}},"item":{"item_json":"{\"citizen-names\":\"West German\",\"country\":\"DE\",\"end-date\":\"1990-10-02\",\"name\":\"West Germany\",\"official-name\":\"Federal Republic of Germany\"}","item_hash":"sha-256:e03f97c2806206cdc2cc0f393d09b18a28c6f3e6218fc8c6f3aa2fdd7ef9d625","parsed_item":null}},{"entry":{"rsf_line":null,"entry_number":71,"parsed_entry":{"key":"DE","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:747dbb718cb9f9799852e7bf698c499e6b83fb1a46ec06dbd6087f35c1e955cc"}},"item":{"item_json":"{\"citizen-names\":\"German\",\"country\":\"DE\",\"name\":\"Germany\",\"official-name\":\"The Federal Republic of Germany\",\"start-date\":\"1990-10-03\"}","item_hash":"sha-256:747dbb718cb9f9799852e7bf698c499e6b83fb1a46ec06dbd6087f35c1e955cc","parsed_item":n
+ull}}]],
+
+...
+
+["AD",[{"entry":{"rsf_line":null,"entry_number":10,"parsed_entry":{"key":"AD","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:14fcb5099f0eff4c40d5a85b0e3c2f1a04337dc69dace1fc5c64ec9758a19b13"}},"item":{"item_json":"{\"citizen-names\":\"Andorran\",\"country\":\"AD\",\"name\":\"Andorra\",\"official-name\":\"The Principality of Andorra\"}","item_hash":"sha-256:14fcb5099f0eff4c40d5a85b0e3c2f1a04337dc69dace1fc5c64ec9758a19b13","parsed_item":null}}]]]"
+
+```
+</details>
+
 ## Items, entries and records
 
-[`ItemCollection`](path/to/item_collection.rb), [`EntryCollection`](path/to/entry_collection.rb) and [`RecordCollection`](path/to/record_collection.rb) are all `Enumerable` and implement the same [Collections](#collections) interface.
+[`ItemCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/item_collection.rb), [`EntryCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/entry_collection.rb) and [`RecordCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/record_collection.rb) are all `Enumerable` and implement the same [Collections](#collections) interface.
 
 ### Item
 
@@ -358,424 +786,3 @@ Expected output (click here to expand):
 "{"item_json":"{\"citizen-names\":\"Czech\",\"country\":\"CZ\",\"name\":\"Czechia\",\"official-name\":\"The Czech Republic\",\"start-date\":\"1993-01-01\"}","item_hash":"sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720","parsed_item":null}"
 ```
 </details>
-
-## Collections
-
-The majority of the methods available in the `RegisterClient` return one of three types of collection object. These collections all include `Enumerable` and implement the `each` method.
-
-### EntryCollection
-
-A collection of `Entry` objects.
-
-#### `each`
-
-Yields each `Entry` object in the collection.
-
-#### `page(int page=1)`
-
-Returns all `Entry` objects in the collection, according to the specified `page` number (defaults to `1`).
-
-If there are fewer results than the current `page_size`, all results are returned.
-
-### RecordCollection
-
-A collection of `Record` objects.
-
-#### `each`
-
-Yields each `Record` object in the collection.
-
-#### `page(int page=1)`
-
-Returns `Record` objects in the collection, according to the specified `page` number (defaults to `1`).
-
-If there are fewer results than the current `page_size`, all results are returned.
-
-### RecordMapCollection
-
-A map of record key to list of both the current and historical `Record` objects for each key.
-
-#### `each`
-
-Yields each record key to list of current and historical `Record` objects in the collection, in the following format:
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_records_with_history.each do |result|
-  puts result.to_json
-end
-
-```
-</details>
-<details>
-<summary>
-Expected output for the first `result` (click here to expand):
- </summary>
-
-```
-
-"{"key":"SU","records":[{"entry":{"rsf_line":null,"entry_number":1,"parsed_entry":{"key":"SU","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"}},"item":{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}}]}"
-
-```
-</details>
-
-#### `get_records_for_key(string key)`
-
-Returns both the current and historical `Record` objects for a given key, or raises a `KeyError` if no records exist for the given key.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_records_with_history.get_records_for_key('SU')
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-
-"{[{"entry":{"rsf_line":null,"entry_number":1,"parsed_entry":{"key":"SU","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"}},"item":{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}}]}"
-
-```
-</details>
-
-#### `paginator`
-
-Returns an enumerator of a map of record key to list of current and historical `Record` objects in the collection, in slices specified by `page_size` (defined when creating the `RegisterClientManager`).
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-enumerator = register_data.get_records_with_history.paginator
-enumerator.next.to_json
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-
-[["SU",[{"entry":{"rsf_line":null,"entry_number":1,"parsed_entry":{"key":"SU","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"}},"item":{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}}]],["DE",[{"entry":{"rsf_line":null,"entry_number":2,"parsed_entry":{"key":"DE","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:e03f97c2806206cdc2cc0f393d09b18a28c6f3e6218fc8c6f3aa2fdd7ef9d625"}},"item":{"item_json":"{\"citizen-names\":\"West German\",\"country\":\"DE\",\"end-date\":\"1990-10-02\",\"name\":\"West Germany\",\"official-name\":\"Federal Republic of Germany\"}","item_hash":"sha-256:e03f97c2806206cdc2cc0f393d09b18a28c6f3e6218fc8c6f3aa2fdd7ef9d625","parsed_item":null}},{"entry":{"rsf_line":null,"entry_number":71,"parsed_entry":{"key":"DE","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:747dbb718cb9f9799852e7bf698c499e6b83fb1a46ec06dbd6087f35c1e955cc"}},"item":{"item_json":"{\"citizen-names\":\"German\",\"country\":\"DE\",\"name\":\"Germany\",\"official-name\":\"The Federal Republic of Germany\",\"start-date\":\"1990-10-03\"}","item_hash":"sha-256:747dbb718cb9f9799852e7bf698c499e6b83fb1a46ec06dbd6087f35c1e955cc","parsed_item":n
-ull}}]],
-
-...
-
-["AD",[{"entry":{"rsf_line":null,"entry_number":10,"parsed_entry":{"key":"AD","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:14fcb5099f0eff4c40d5a85b0e3c2f1a04337dc69dace1fc5c64ec9758a19b13"}},"item":{"item_json":"{\"citizen-names\":\"Andorran\",\"country\":\"AD\",\"name\":\"Andorra\",\"official-name\":\"The Principality of Andorra\"}","item_hash":"sha-256:14fcb5099f0eff4c40d5a85b0e3c2f1a04337dc69dace1fc5c64ec9758a19b13","parsed_item":null}}]]]"
-
-```
-</details>
-
-## <a id="registerclient"></a>The `RegisterClient` class
-
-_Note: All examples use the [Country register](https://country.register.gov.uk/)._
-
-### `get_entries`
-
-Get all entries from the register.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_entries.first.item_hash
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-
-sha-256:a074752a77011b18447401652029a9129c53b4ee35e1d99e6dec8b42ff4a0103
-
-```
-</details>
-
-### `get_records`
-
-Get all records from the register.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_records.first.item.value
-
-```
-</details>
-<details>
-
-<summary>
-Expected output (click here to expand):
-</summary>
-
-```
-
-{"citizen-names"=>"Soviet citizen", "country"=>"SU", "end-date"=>"1991-12-25", "name"=>"USSR", "official-name"=>"Union of Soviet Socialist Republics"}
-
-```
-
-</details>
-
-### `get_metadata_records`
-
-Get all metadata records of the register. This includes the register definition, field definitions and custodian.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_metadata_records.first.item.value
-
-```
-</details>
-<details>
-
-<summary>
-Expected output (click here to expand):
-</summary>
-
-```
-
-{"name"=>"country"}
-
-```
-</details>
-
-### `get_field_definitions`
-
-Get definitions for the fields used in the register.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_field_definitions.first.item.value
-
-```
-
-</details>
-<details>
-
-<summary>
-Expected output (click here to expand):
-</summary>
-
-```
-
-{"cardinality"=>"1", "datatype"=>"string", "field"=>"country", "phase"=>"beta", "register"=>"country", "text"=>"The country's 2-letter ISO 3166-2 alpha2 code."}
-
-```
-
-</details>
-
-### `get_register_definition`
-
-Get the definition of the register.
-
-<details>
-<summary>
-Example use (click here to expand):
- </summary>
-
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_register_definition.item.value
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
-</summary>
-
-```
-
-{"fields":["country","name","official-name","citizen-names","start-date","end-date"],"phase":"beta","register":"country","registry":"foreign-commonwealth-office","text":"British English-language names and descriptive terms for countries"}
-
-```
-
-</details>
-
-### `get_custodian`
-
-Get the name of the current custodian for the register.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_custodian.item.value['custodian']
-
-```
-
-</details>
-<details>
-
-<summary>
-Expected output (click here to expand):
-</summary>
-
-```
-
-David de Silva
-
-```
-
-</details>
-
-### `get_records_with_history`
-
-Get current and previous versions of records in the register.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-germany = register_data.get_records_with_history.get_records_for_key('DE').first
-puts germany.to_json
-
-```
-
-</details>
-
-<details>
-<summary>
-Expected output (click here to expand):
-</summary>
-
-```
-
-{"key":"DE","records":[{"key":"DE","entry_number":234,"timestamp":"2016-04-05T13:23:05Z","hash":"sha-256:e03f97c2806206cdc2cc0f393d09b18a28c6f3e6218fc8c6f3aa2fdd7ef9d625","item":{"citizen-names":"West German","country":"DE","end-date":"1990-10-02","name":"West Germany","official-name":"Federal Republic of Germany"}}
-
-```
-
-</details>
-
-### `get_current_records`
-
-Get all current records from the register.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_current_records.first.item
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
-</summary>
-
-```
-
-{"citizen-names"=>"German", "country"=>"DE", "name"=>"Germany", "official-name"=>"The Federal Republic of Germany", "start-date"=>"1990-10-03"}
-
-```
-
-</details>
-
-### `get_expired_records`
-
-Get all expired records from the register.
-
-<details>
-<summary>
-Example use (click here to expand)
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-register_data.get_expired_records.first.item
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand)
-</summary>
-
-```
-
-{"citizen-names"=>"Soviet citizen", "country"=>"SU", "end-date"=>"1991-12-25", "name"=>"USSR", "official-name"=>"Union of Soviet Socialist Republics"}
-
-```
-
-</details>
-
-### `refresh_data`
-
-Downloads register data. Call this method when you want to refresh data immediately rather than waiting for the `cache_duration` to expire.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Registers are authoritative lists of information. The data is owned by [custodia
   * [`RegisterClientManager`](#registerclientmanager)
   * [`RegisterClient`](#registerclient) 
   * [Collections](#collections)  
-  * [`Entry`, `Item` and `Record`](#entry-item-and-record)
 
 ## Installation
 
@@ -384,6 +383,147 @@ Returns all `Entry` objects in the collection, according to the specified `page`
 
 If there are fewer results than the current `page_size`, all results are returned.
 
+### `Entry`
+
+#### `entry_number`
+
+Gets the entry number of the entry.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
+entry.entry_number
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+52
+```
+</details>
+
+##### `key`
+
+Gets the key of the entry.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+register_data = registers_client.get_register('country', 'beta')
+
+entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
+entry.key
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+CZ
+```
+</details>
+
+##### `timestamp`
+
+Gets the timestamp of when the entry was appended to the register.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
+entry.timestamp
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+2016-04-05T13:23:05Z
+```
+</details>
+
+##### `item_hash`
+
+Gets the SHA-256 hash of the item which the entry points to.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
+entry.item_hash
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed
+```
+</details>
+
+##### `value`
+
+Returns the entry as a hash.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
+entry.value.to_json
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+"{"key":"CZ","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed"}"
+```
+</details>
+
 ### `RecordCollection`
 
 A collection of `Record` objects.
@@ -397,6 +537,65 @@ Yields each `Record` object in the collection.
 Returns `Record` objects in the collection, according to the specified `page` number (defaults to `1`).
 
 If there are fewer results than the current `page_size`, all results are returned.
+
+### `Record`
+
+#### `entry`
+
+Gets the `Entry` object associated with the record.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+record = register_data.get_records.select {|record| record.entry.key == 'CZ'}.first
+record.entry.to_json
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+"{"entry_number":205,"parsed_entry":{"key":"CZ","timestamp":"2016-11-11T16:25:07Z","item_hash":"sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720"}}"
+```
+</details>
+
+#### `item`
+
+Gets the `Item` object associated with the record.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+record = register_data.get_records.select {|record| record.entry.key == 'CZ'}.first
+record.item.to_json
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+"{"item_json":"{\"citizen-names\":\"Czech\",\"country\":\"CZ\",\"name\":\"Czechia\",\"official-name\":\"The Czech Republic\",\"start-date\":\"1993-01-01\"}","item_hash":"sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720","parsed_item":null}"
+```
+</details>
+
 
 ### `RecordMapCollection`
 
@@ -497,149 +696,6 @@ ull}}]],
 ```
 </details>
 
-## <a id="entry-item-and-record"></a>`Entry`, `Item` and `Record`
-
-### `Entry`
-
-#### `entry_number`
-
-Gets the entry number of the entry.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
-entry.entry_number
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-52
-```
-</details>
-
-#### `key`
-
-Gets the key of the entry.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-register_data = registers_client.get_register('country', 'beta')
-
-entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
-entry.key
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-CZ
-```
-</details>
-
-#### `timestamp`
-
-Gets the timestamp of when the entry was appended to the register.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
-entry.timestamp
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-2016-04-05T13:23:05Z
-```
-</details>
-
-#### `item_hash`
-
-Gets the SHA-256 hash of the item which the entry points to.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
-entry.item_hash
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed
-```
-</details>
-
-#### `value`
-
-Returns the entry as a hash.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-entry = register_data.get_entries.select {|entry| entry.key == 'CZ'}.first
-entry.value.to_json
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-"{"key":"CZ","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed"}"
-```
-</details>
-
 ### `Item`
 
 #### `hash`
@@ -729,60 +785,3 @@ true
 ```
 </details>
 
-### `Record`
-
-#### `entry`
-
-Gets the `Entry` object associated with the record.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-record = register_data.get_records.select {|record| record.entry.key == 'CZ'}.first
-record.entry.to_json
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-"{"entry_number":205,"parsed_entry":{"key":"CZ","timestamp":"2016-11-11T16:25:07Z","item_hash":"sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720"}}"
-```
-</details>
-
-#### `item`
-
-Gets the `Item` object associated with the record.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-record = register_data.get_records.select {|record| record.entry.key == 'CZ'}.first
-record.item.to_json
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-"{"item_json":"{\"citizen-names\":\"Czech\",\"country\":\"CZ\",\"name\":\"Czechia\",\"official-name\":\"The Czech Republic\",\"start-date\":\"1993-01-01\"}","item_hash":"sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720","parsed_item":null}"
-```
-</details>

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Registers are authoritative lists of information. The data is owned by [custodia
   * [`RegisterClient`](#registerclient) 
   * [Collections](#collections) 
     + [EntryCollection](#entrycollection)
+    + [Entry](#entry)
     + [ItemCollection](#itemcollection)
+    + [Item](#item)
     + [RecordCollection](#recordcollection)
+    + [Record](#record) 
     + [RecordMapCollection](#recordmapcollection) 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Registers are authoritative lists of information. The data is owned by [custodia
   * [`RegisterClientManager`](#registerclientmanager)
   * [`RegisterClient`](#registerclient) 
   * [Collections](#collections)  
+  * [`Entry`, `Item` and `Record`](#entry-item-and-record)
 
 ## Installation
 
@@ -366,7 +367,8 @@ Downloads register data. Call this method when you want to refresh data immediat
 
 The majority of the methods available in the `RegisterClient` return one of three types of collection object. These collections all include `Enumerable` and implement the `each` method.
 
-[`ItemCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/item_collection.rb), [`EntryCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/entry_collection.rb) and [`RecordCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/record_collection.rb) are all `Enumerable` and implement the same [Collections](#collections) interface.
+[`EntryCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/entry_collection.rb),
+[`ItemCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/item_collection.rb)  and [`RecordCollection`](https://github.com/openregister/registers-ruby-client/blob/master/lib/record_collection.rb) are all `Enumerable` and implement the same [Collections](#collections) interface.
 
 ### `EntryCollection`
 
@@ -495,94 +497,7 @@ ull}}]],
 ```
 </details>
 
-### `Item`
-
-#### `hash`
-
-Returns the SHA-256 hash of the item.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
-item.hash
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-
-"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"
-
-```
-</details>
-
-#### `value`
-
-Returns the key-value pairs represented by the item in a `JSON` object.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
-item.value
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-
-{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}
-
-```
-</details>
-
-#### `has_end_date`
-
-Returns a boolean to describe whether the item contains a key-value pair for the `end-date` field.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
-item.has_end_date
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-true
-```
-</details>
+## <a id="entry-item-and-record"></a>`Entry`, `Item` and `Record`
 
 ### `Entry`
 
@@ -722,6 +637,95 @@ Expected output (click here to expand):
 
 ```
 "{"key":"CZ","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed"}"
+```
+</details>
+
+### `Item`
+
+#### `hash`
+
+Returns the SHA-256 hash of the item.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
+item.hash
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+
+"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"
+
+```
+</details>
+
+#### `value`
+
+Returns the key-value pairs represented by the item in a `JSON` object.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
+item.value
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+
+{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}
+
+```
+</details>
+
+#### `has_end_date`
+
+Returns a boolean to describe whether the item contains a key-value pair for the `end-date` field.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
+item.has_end_date
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+true
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ Registers are authoritative lists of information. The data is owned by [custodia
 - [Reference](#reference)
   * [`RegisterClientManager`](#registerclientmanager)
   * [`RegisterClient`](#registerclient) 
-  * [Collections](#collections)  
+  * [Collections](#collections) 
+    + [EntryCollection](#entrycollection)
+    + [ItemCollection](#itemcollection)
+    + [RecordCollection](#recordcollection)
+    + [RecordMapCollection](#recordmapcollection) 
 
 ## Installation
 
@@ -524,6 +528,109 @@ Expected output (click here to expand):
 ```
 </details>
 
+### `ItemCollection`
+
+A collection of `Item` objects.
+
+#### `each`
+
+Yields each `Item` object in the collection.
+
+#### `page(int page=1)`
+
+Returns all `Item` objects in the collection, according to the specified `page` number (defaults to `1`).
+
+If there are fewer results than the current `page_size`, all results are returned.
+
+### `Item`
+
+#### `hash`
+
+Returns the SHA-256 hash of the item.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
+item.hash
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+
+"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"
+
+```
+</details>
+
+#### `value`
+
+Returns the key-value pairs represented by the item in a `JSON` object.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
+item.value
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+
+{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}
+
+```
+</details>
+
+#### `has_end_date`
+
+Returns a boolean to describe whether the item contains a key-value pair for the `end-date` field.
+
+<details>
+<summary>
+Example use (click here to expand):
+</summary>
+
+```
+
+register_data = registers_client.get_register('country', 'beta')
+
+item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
+item.has_end_date
+
+```
+</details>
+<details>
+<summary>
+Expected output (click here to expand):
+ </summary>
+
+```
+true
+```
+</details>
+
 ### `RecordCollection`
 
 A collection of `Record` objects.
@@ -693,95 +800,6 @@ ull}}]],
 
 ["AD",[{"entry":{"rsf_line":null,"entry_number":10,"parsed_entry":{"key":"AD","timestamp":"2016-04-05T13:23:05Z","item_hash":"sha-256:14fcb5099f0eff4c40d5a85b0e3c2f1a04337dc69dace1fc5c64ec9758a19b13"}},"item":{"item_json":"{\"citizen-names\":\"Andorran\",\"country\":\"AD\",\"name\":\"Andorra\",\"official-name\":\"The Principality of Andorra\"}","item_hash":"sha-256:14fcb5099f0eff4c40d5a85b0e3c2f1a04337dc69dace1fc5c64ec9758a19b13","parsed_item":null}}]]]"
 
-```
-</details>
-
-### `Item`
-
-#### `hash`
-
-Returns the SHA-256 hash of the item.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
-item.hash
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-
-"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a"
-
-```
-</details>
-
-#### `value`
-
-Returns the key-value pairs represented by the item in a `JSON` object.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
-item.value
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-
-{"item_json":"{\"citizen-names\":\"Soviet citizen\",\"country\":\"SU\",\"end-date\":\"1991-12-25\",\"name\":\"USSR\",\"official-name\":\"Union of Soviet Socialist Republics\"}","item_hash":"sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a","parsed_item":null}
-
-```
-</details>
-
-#### `has_end_date`
-
-Returns a boolean to describe whether the item contains a key-value pair for the `end-date` field.
-
-<details>
-<summary>
-Example use (click here to expand):
-</summary>
-
-```
-
-register_data = registers_client.get_register('country', 'beta')
-
-item = register_data.get_records.select {|record| record.entry.key == 'SU'}.first.item
-item.has_end_date
-
-```
-</details>
-<details>
-<summary>
-Expected output (click here to expand):
- </summary>
-
-```
-true
 ```
 </details>
 


### PR DESCRIPTION

### Context

This README is "non-standard" from a Ruby documentation perspective, given that this information does not yet exist anywhere else, but we're going to run with this alongside more standard documentation to be implemented later 

@arnau and I have discussed splitting the two sections before we do UR on this which is what this PR covers

If you could review this @arnau and let me know what your thoughts are: it doesn't exactly match what we discussed, I know, but I can make changes as usual based on discussions


### Changes proposed in this pull request


### Guidance to review
