### PR TITLE
Correctly detect a reloaded remote register

### DIFF
--- a/lib/data_store.rb
+++ b/lib/data_store.rb
@@ -26,6 +26,12 @@ module DataStore
   def get_latest_entry_number(entry_type)
   end
 
+  def get_root_hash
+  end
+
+  def set_root_hash(root_hash)
+  end
+
   def after_load
   end
 end

--- a/lib/exceptions/invalid_hash_value_error.rb
+++ b/lib/exceptions/invalid_hash_value_error.rb
@@ -1,0 +1,5 @@
+class InvalidHashValueError < StandardError
+    def initialize(msg='Value must be a sha-256 hash string prefixed with "sha-256:"')
+        super
+    end
+end

--- a/lib/in_memory_data_store.rb
+++ b/lib/in_memory_data_store.rb
@@ -21,8 +21,6 @@ module RegistersClient
         records: { user: {}, system: {} },
         entries: { user: [], system: [] },
         items: {},
-        user_entry_number: 0,
-        system_entry_number: 0,
         root_hash: ''
       }
 

--- a/lib/in_memory_data_store.rb
+++ b/lib/in_memory_data_store.rb
@@ -21,7 +21,7 @@ module RegistersClient
         records: { user: {}, system: {} },
         entries: { user: [], system: [] },
         items: {},
-        root_hash: ''
+        root_hash: EMPTY_ROOT_HASH
       }
 
     end
@@ -87,7 +87,7 @@ module RegistersClient
     end
 
     def get_root_hash
-      get_latest_entry_number(:user) > 0 ? @data[:root_hash] : EMPTY_ROOT_HASH
+      @data[:root_hash]
     end
 
     def set_root_hash(root_hash)

--- a/lib/in_memory_data_store.rb
+++ b/lib/in_memory_data_store.rb
@@ -12,6 +12,8 @@ module RegistersClient
   class InMemoryDataStore
     include DataStore
 
+    EMPTY_ROOT_HASH = 'sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
     def initialize(config_options)
       @config_options = config_options
 
@@ -20,7 +22,8 @@ module RegistersClient
         entries: { user: [], system: [] },
         items: {},
         user_entry_number: 0,
-        system_entry_number: 0
+        system_entry_number: 0,
+        root_hash: ''
       }
 
     end
@@ -83,6 +86,14 @@ module RegistersClient
       entries = @data[:entries][entry_type]
       entry = entries.any? ? entries.last : nil
       entry.nil? ? 0 : entry.entry_number
+    end
+
+    def get_root_hash
+      get_latest_entry_number(:user) > 0 ? @data[:root_hash] : EMPTY_ROOT_HASH
+    end
+
+    def set_root_hash(root_hash)
+      @data[:root_hash] = root_hash
     end
 
     def after_load

--- a/lib/register_client.rb
+++ b/lib/register_client.rb
@@ -114,14 +114,10 @@ module RegistersClient
 
     def validate_register_integrity(rsf, current_entry_number)
       rsf_lines = rsf.split("\n")
-      latest_root_hash = rsf_lines[rsf_lines.length - 1].split("\t")[1]
-      register_proof = get_register_proof
+      expected_root_hash = rsf_lines[0].split("\t")[1]
+      local_root_hash = @data_store.get_root_hash
 
-      if (register_proof['total-entries'] < current_entry_number)
-        raise InvalidRegisterError, 'Register has been reloaded with different data - different number of entries'
-      end
-
-      if (register_proof['root-hash'] != latest_root_hash)
+      if (local_root_hash != expected_root_hash)
         raise InvalidRegisterError, 'Register has been reloaded with different data - root hashes do not match'
       end
     end
@@ -152,6 +148,9 @@ module RegistersClient
           end
 
           data_store.append_entry(entry)
+        elsif command == 'assert-root-hash'
+          root_hash = line.split("\t")[1]
+          data_store.set_root_hash(root_hash)
         end
       end
 

--- a/lib/register_client.rb
+++ b/lib/register_client.rb
@@ -1,6 +1,7 @@
 require 'rest-client'
 require 'json'
 require 'exceptions/invalid_register_error'
+require 'exceptions/invalid_hash_value_error'
 
 module RegistersClient
   class RegisterClient
@@ -73,6 +74,14 @@ module RegistersClient
 
     def get_expired_records
       RecordCollection.new(get_records.select { |record| record.item.has_end_date }, @page_size)
+    end
+
+    def get_root_hash
+      root_hash = @data_store.get_root_hash
+      if !is_valid_hash_value(root_hash)
+        raise InvalidHashValueError
+      end
+      return root_hash
     end
 
     def refresh_data
@@ -159,6 +168,10 @@ module RegistersClient
 
     def register_http_request(path)
       RestClient.get(@register_url.merge(path).to_s)
+    end
+
+    def is_valid_hash_value(hash_value)
+      (/sha-256:+\h{64}/) === hash_value
     end
   end
 end

--- a/spec/fixtures/country_register_reload.rsf
+++ b/spec/fixtures/country_register_reload.rsf
@@ -1,0 +1,8 @@
+assert-root-hash	sha-256:b101a2447dad89c75b30845a194eb1b55bd7f2f876b47ed35dd82c35c2a4ea17
+add-item	{"custodian":"Joseph Bloggs"}
+add-item	{"citizen-names":"Briton;British citizen","country":"GB","name":"United Kingdom","official-name":"United Kingdom of Great Britain and Northern Ireland"}
+add-item	{"citizen-names":"Bahamian","country":"BS","name":"The Bahamas","official-name":"The Commonwealth of The Bahamas"}
+append-entry	user	BS	2016-04-05T13:23:05Z	sha-256:a77f1e11270aab0c5bf315b2e7c268a7aff89713578020e1b4183c6df2b2c0e7
+append-entry	user	GB	2016-04-05T13:23:05Z	sha-256:0c87b0f2a098f0766aa8f5a06a069220207060ee197ea36925debcaadbe5b8aa
+append-entry	system	custodian	2017-11-02T11:18:00Z	sha-256:b065307fdd285aa0920bd08eee83824c0e923cfb5422e7dc4488455168e3bdc0
+assert-root-hash	sha-256:61fa13e7f2a0960382ecbbb4e7e72ebe808b05a2d1b6ee72c7434195a0b74bd4

--- a/spec/in_memory_data_store_spec.rb
+++ b/spec/in_memory_data_store_spec.rb
@@ -258,18 +258,7 @@ RSpec.describe RegistersClient::InMemoryDataStore do
     @config_options = { page_size: 2, cache_duration: 30 }.merge(config_options)
     @page_size = 100
 
-    register_proof_for_country_rsf = {
-        "total-entries" => 7,
-        "root-hash" => 'sha-256:401ce60c619a0bd305264adb5f3992f19b758ded8754e0ffe0bed3832b3de28d'
-    }
-
-    register_proof_for_country_update_rsf = {
-        "total-entries" => 9,
-        "root-hash" => 'sha-256:fa87bc961ed7fa6dde75db82cda8a6df8d8427da36bbf448fff6b177c2486cdb'
-    }
-
     allow_any_instance_of(RegistersClient::RegisterClient).to receive(:download_rsf).with(0).and_return(rsf)
-    allow_any_instance_of(RegistersClient::RegisterClient).to receive(:get_register_proof).and_return(register_proof_for_country_rsf, register_proof_for_country_update_rsf)
 
     @data_store = RegistersClient::InMemoryDataStore.new(@config_options)
 

--- a/spec/register_client_spec.rb
+++ b/spec/register_client_spec.rb
@@ -455,8 +455,9 @@ RSpec.describe RegistersClient::RegisterClient do
       data_store = instance_double("InMemoryDataStore")
       allow(data_store).to receive(:get_latest_entry_number).with(:user).and_return(9)
       allow(data_store).to receive(:get_latest_entry_number).with(:system).and_return(13)
+      allow(data_store).to receive(:set_root_hash).with('sha-256:fa87bc961ed7fa6dde75db82cda8a6df8d8427da36bbf448fff6b177c2486cdb')
+      allow(data_store).to receive(:get_root_hash).and_return('sha-256:fa87bc961ed7fa6dde75db82cda8a6df8d8427da36bbf448fff6b177c2486cdb')
       allow(data_store).to receive(:after_load)
-      allow_any_instance_of(RegistersClient::RegisterClient).to receive(:get_register_proof).and_return(@register_proof_for_country_update_rsf)
 
       RegistersClient::RegisterClient.new(URI.parse('https://country.test.openregister.org'), data_store, @page_size)
 
@@ -464,26 +465,12 @@ RSpec.describe RegistersClient::RegisterClient do
       expect(data_store).to have_received(:get_latest_entry_number).with(:system)
     end
 
-    it 'should throw an InvalidRegisterError when there are less entries in the register than there are in memory' do
+    it 'should throw an InvalidRegisterError when the expected current root hash from the downloaded RSF file does not match the local root hash' do
       client = RegistersClient::RegisterClient.new(URI.parse('https://country.test.openregister.org'), @data_store, @page_size)
 
-      reloaded_register_proof = {
-          "total-entries" => 4,
-          "root-hash" => 'sha-256:b101a2447dad89c75b30845a194eb1b55bd7f2f876b47ed35dd82c35c2a4ea17'
-      }
-      allow(client).to receive(:get_register_proof).and_return(reloaded_register_proof)
-
-      expect{client.refresh_data}.to raise_error(InvalidRegisterError, 'Register has been reloaded with different data - different number of entries')
-    end
-
-    it 'should throw an InvalidRegisterError when the latest root hash from the downloaded RSF file does not match the register proof' do
-      client = RegistersClient::RegisterClient.new(URI.parse('https://country.test.openregister.org'), @data_store, @page_size)
-
-      reloaded_register_proof = {
-          "total-entries" => 7,
-          "root-hash" => 'sha-256:b101a2447dad89c75b30845a194eb1b55bd7f2f876b47ed35dd82c35c2a4ea17'
-      }
-      allow(client).to receive(:get_register_proof).and_return(reloaded_register_proof)
+      dir = File.dirname(__FILE__)
+      reload_rsf = File.read(File.join(dir, 'fixtures/country_register_reload.rsf'))
+      allow(client).to receive(:download_rsf).with(7).and_return(reload_rsf)
 
       expect{client.refresh_data}.to raise_error(InvalidRegisterError, 'Register has been reloaded with different data - root hashes do not match')
     end
@@ -502,17 +489,5 @@ RSpec.describe RegistersClient::RegisterClient do
     allow_any_instance_of(RegistersClient::RegisterClient).to receive(:download_rsf).with(0).and_return(rsf)
     allow_any_instance_of(RegistersClient::RegisterClient).to receive(:download_rsf).with(7).and_return(update_rsf)
     allow_any_instance_of(RegistersClient::RegisterClient).to receive(:download_rsf).with(9).and_return(no_new_updates_rsf)
-
-    register_proof_for_country_rsf = {
-        "total-entries" => 7,
-        "root-hash" => 'sha-256:401ce60c619a0bd305264adb5f3992f19b758ded8754e0ffe0bed3832b3de28d'
-    }
-
-    @register_proof_for_country_update_rsf = {
-        "total-entries" => 9,
-        "root-hash" => 'sha-256:fa87bc961ed7fa6dde75db82cda8a6df8d8427da36bbf448fff6b177c2486cdb'
-    }
-
-    allow_any_instance_of(RegistersClient::RegisterClient).to receive(:get_register_proof).and_return(register_proof_for_country_rsf, @register_proof_for_country_update_rsf)
   end
 end


### PR DESCRIPTION
### Context
The existing code does not correctly detect when a remote register
is inconsistent with the local register. This can happen in the
alpha and discovery environments where we reload registers and do
not follow the append-only rule.

### Changes proposed in this pull request
Previously the code was comparing the last root hash in the RSF against
the current root hash of the remote register (this will almost always
match). Instead, the code should be comparing the first root hash of
the RSF against the current root hash of the local register. This is
the definition of that `assert-root-hash` command.

For now, we do not want to do the work in the library to compute
the root hash. As a temporary measure we will therefore set the
root hash value in the client by callign the `set_root_hash` method
in the DataStore. The proper thing to do is to remove this method and
calculate the root hash from the entries in the register, but we
can do this work later.

The comparison between latest entry number was removed, because if
the size of the register differs, the root-hashes will also differ.

I will update the version in a later PR once this one is approved. As suggested by @arnau this means that we can include multiple PRs in a new version if we create separate PRs to increment a version.