### PR TITLE
Update code examples for RegisterClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_entries.first.item_hash
+register_data.get_entries
 
 ```
 </details>
@@ -107,7 +107,7 @@ Expected output (click here to expand):
 
 ```
 
-sha-256:a074752a77011b18447401652029a9129c53b4ee35e1d99e6dec8b42ff4a0103
+An EntryCollection instance.
 
 ```
 </details>
@@ -126,7 +126,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_records.first.item.value
+register_data.get_records
 
 ```
 </details>
@@ -138,7 +138,7 @@ Expected output (click here to expand):
 
 ```
 
-{"citizen-names"=>"Soviet citizen", "country"=>"SU", "end-date"=>"1991-12-25", "name"=>"USSR", "official-name"=>"Union of Soviet Socialist Republics"}
+A RecordCollection instance.
 
 ```
 
@@ -158,7 +158,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_metadata_records.first.item.value
+register_data.get_metadata_records
 
 ```
 </details>
@@ -170,7 +170,7 @@ Expected output (click here to expand):
 
 ```
 
-{"name"=>"country"}
+A RecordCollection instance.
 
 ```
 </details>
@@ -189,7 +189,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_field_definitions.first.item.value
+register_data.get_field_definitions
 
 ```
 
@@ -202,7 +202,7 @@ Expected output (click here to expand):
 
 ```
 
-{"cardinality"=>"1", "datatype"=>"string", "field"=>"country", "phase"=>"beta", "register"=>"country", "text"=>"The country's 2-letter ISO 3166-2 alpha2 code."}
+A RecordCollection instance.
 
 ```
 
@@ -222,7 +222,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_register_definition.item.value
+register_data.get_register_definition
 
 ```
 </details>
@@ -233,7 +233,7 @@ Expected output (click here to expand):
 
 ```
 
-{"fields":["country","name","official-name","citizen-names","start-date","end-date"],"phase":"beta","register":"country","registry":"foreign-commonwealth-office","text":"British English-language names and descriptive terms for countries"}
+A Record instance.
 
 ```
 
@@ -253,7 +253,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_custodian.item.value['custodian']
+register_data.get_custodian
 
 ```
 
@@ -266,7 +266,7 @@ Expected output (click here to expand):
 
 ```
 
-David de Silva
+A Record instance.
 
 ```
 
@@ -285,8 +285,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-germany = register_data.get_records_with_history.get_records_for_key('DE').first
-puts germany.to_json
+germany = register_data.get_records_with_history
 
 ```
 
@@ -299,7 +298,7 @@ Expected output (click here to expand):
 
 ```
 
-{"key":"DE","records":[{"key":"DE","entry_number":234,"timestamp":"2016-04-05T13:23:05Z","hash":"sha-256:e03f97c2806206cdc2cc0f393d09b18a28c6f3e6218fc8c6f3aa2fdd7ef9d625","item":{"citizen-names":"West German","country":"DE","end-date":"1990-10-02","name":"West Germany","official-name":"Federal Republic of Germany"}}
+A RecordMapCollection instance.
 
 ```
 
@@ -318,7 +317,7 @@ Example use (click here to expand):
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_current_records.first.item
+register_data.get_current_records
 
 ```
 </details>
@@ -329,7 +328,7 @@ Expected output (click here to expand):
 
 ```
 
-{"citizen-names"=>"German", "country"=>"DE", "name"=>"Germany", "official-name"=>"The Federal Republic of Germany", "start-date"=>"1990-10-03"}
+A RecordCollection instance.
 
 ```
 
@@ -348,7 +347,7 @@ Example use (click here to expand)
 
 register_data = registers_client.get_register('country', 'beta')
 
-register_data.get_expired_records.first.item
+register_data.get_expired_records
 
 ```
 </details>
@@ -359,7 +358,7 @@ Expected output (click here to expand)
 
 ```
 
-{"citizen-names"=>"Soviet citizen", "country"=>"SU", "end-date"=>"1991-12-25", "name"=>"USSR", "official-name"=>"Union of Soviet Socialist Republics"}
+A RecordCollection instance.
 
 ```
 


### PR DESCRIPTION
### Context

This PR updates the code examples for the main methods of `RegisterClient` to make them consistent and to remove the potential confusion surrounding them. For example, the code example for `get_records` would previously only return the first item of the first record because of the `.first.item.value` at the end of the call to `get_records`. The method now returns the correct collection object, `RecordCollection`.

### Changes proposed in this pull request

Update the code examples for `RegisterClient` to be consistent and less confusing. This is particularly important for the upcoming user research sessions on the client library.

### Guidance to review

